### PR TITLE
Improve message flow diagram

### DIFF
--- a/STAR-Delegation/art/e2e-flow.ascii-art
+++ b/STAR-Delegation/art/e2e-flow.ascii-art
@@ -15,8 +15,8 @@
     |   CSR              |       |                    |
     |   Signature        |       |                    |
     o------------------->|       |                    |
-    |                    |       |   Order'           |
-    |                    |       |   Signature        |
+    |   Acknowledgement  |       |   Order'           |
+    |<-------------------o       |   Signature        |
     |                    |       o------------------->|
     |                    |       |         Required   |
     |                    |       |   Authorizations   |
@@ -30,14 +30,22 @@
     |                    |       |   CSR              |
     |                    |       |   Signature        |
     |                    |       o------------------->|
+    |                    |       |   Acknowledgement  |
+    |                    |       |<-------------------o
     |                    |       |                    |
     |<~~Await issuance~->|       |<~~Await issuance~~>|
     |                                                 |
+    |     (unauthenticated) GET STAR certificate      |
+    o------------------------------------------------>|
     |                 Certificate #1                  |
     |<------------------------------------------------o
+    |     (unauthenticated) GET STAR certificate      |
+    o------------------------------------------------>|
     |                 Certificate #2                  |
     |<------------------------------------------------o
     |                     [...]                       |
+    |     (unauthenticated) GET STAR certificate      |
+    o------------------------------------------------>|
     |                 Certificate #n                  |
     |<------------------------------------------------o
 


### PR DESCRIPTION
Add missing messages:
- the acknowledgement from right to left after the CSR+Signature message
- the request for the certificate as plain GET from NDC to ACME Server.

Closes #50