### PR TITLE
add some unit tests

### DIFF
--- a/STAR-Delegation/CSR-template/Makefile
+++ b/STAR-Delegation/CSR-template/Makefile
@@ -17,22 +17,22 @@ check-example: $(CDDL_SCHEMA) $(EXAMPLE)
 	$(cddl) $< validate $(EXAMPLE)
 
 test-cddl-schema: $(CDDL_SCHEMA) $(TESTFILES)
-	@echo ">> testing against CDDL schema ($<)"
+	@echo "## testing against CDDL schema ($<)"
 	@for f in $(TESTFILES); do \
-		$(cddl) $< validate $$f ; \
+		$(cddl) $< validate $$f &> /dev/null ; \
 		case $$f in \
-		*GOOD_*) [ $$? -eq 0 ] && echo "[OK] $$f" ;; \
-		*FAIL_*) [ $$? -ne 0 ] && echo "[OK] $$f" ;; \
+		*GOOD_*) [ $$? -eq 0 ] && echo "[OK] $$f" || echo ">> [KO] $$f" ;; \
+		*FAIL_*) [ $$? -ne 0 ] && echo "[OK] $$f" || echo ">> [KO] $$f" ;; \
 		esac ; \
 	done
 
 test-json-schema: $(JSON_SCHEMA) $(TESTFILES)
-	@echo ">> testing against JSON schema ($<)"
+	@echo "## testing against JSON schema ($<)"
 	@for f in $(TESTFILES); do \
-		$(ajv) validate --spec=draft7 -c ajv-formats -s $< -d $$f ; \
+		$(ajv) validate --spec=draft7 -c ajv-formats -s $< -d $$f &> /dev/null ; \
 		case $$f in \
-		*GOOD_*) [ $$? -eq 0 ] && echo "[OK] $$f" ;; \
-		*FAIL_*) [ $$? -ne 0 ] && echo "[OK] $$f" ;; \
+		*GOOD_*) [ $$? -eq 0 ] && echo "[OK] $$f" || echo ">> [KO] $$f" ;; \
+		*FAIL_*) [ $$? -ne 0 ] && echo "[OK] $$f" || echo ">> [KO] $$f" ;; \
 		esac ; \
 	done
 

--- a/STAR-Delegation/CSR-template/template-schema.cddl
+++ b/STAR-Delegation/CSR-template/template-schema.cddl
@@ -13,6 +13,8 @@ regtext = text .regexp "([^\*].*)|([\*][^\*].*)|([\*][\*].+)"
 
 regtext-or-wildcard = regtext / wildcard
 
+; TODO(tho) make explicit in text that DN, if present, can't be empty
+; See test/FAIL_empty_DN.json
 distinguishedName = {
   ? country: regtext-or-wildcard
   ? stateOrProvince: regtext-or-wildcard
@@ -61,9 +63,11 @@ $ecdsaSignatureType /= "ecdsa-with-SHA256" ; paired with secp256r1
 $ecdsaSignatureType /= "ecdsa-with-SHA384" ; paired with secp384r1
 $ecdsaSignatureType /= "ecdsa-with-SHA512" ; paired with secp521r1
 
+; TODO(tho) make explicit in text that SAN can't be empty
+; (See test/FAIL_empty_SAN.json)
 subjectaltname = {
-  ? DNS: [ 1* regtext-or-wildcard ] ; TODO(tho) add checking wildcard to sec cons
-  ? Email: [ 1* regtext ]
+  ? DNS: [ 1* regtext-or-wildcard ] ; TODO(tho) make syntax explicit in text
+  ? Email: [ 1* regtext ] ; TODO(tho) make syntax explicit in text
   ? URI: [ 1* uriType ]
   * $$subjectaltname-extension
 }

--- a/STAR-Delegation/CSR-template/template-schema.json
+++ b/STAR-Delegation/CSR-template/template-schema.json
@@ -6,6 +6,7 @@
     "distinguished-name": {
       "$id": "#distinguished-name",
       "type": "object",
+      "minProperties": 1,
       "properties": {
         "country": {
           "type": "string"
@@ -119,6 +120,7 @@
       "properties": {
         "keyUsage": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
             "enum": [
@@ -136,6 +138,7 @@
         },
         "extendedKeyUsage": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
             "enum": [
@@ -150,35 +153,19 @@
         },
         "subjectAltName": {
           "type": "object",
+          "minProperties": 1,
           "properties": {
             "DNS": {
               "type": "array",
+              "minItems": 1,
               "items": {
                 "type": "string",
                 "format": "hostname"
               }
             },
-            "IP": {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                    "format": "ipv4"
-                  },
-                  {
-                    "type": "string",
-                    "format": "ipv6"
-                  },
-                  {
-                    "type": "string",
-                    "enum": [ "*", "**" ]
-                  }
-                ]
-              }
-            },
             "Email": {
               "type": "array",
+              "minItems": 1,
               "items": {
                 "type": "string",
                 "format": "email"
@@ -186,6 +173,7 @@
             },
             "URI": {
               "type": "array",
+              "minItems": 1,
               "items": {
                 "type": "string",
                 "format": "uri"

--- a/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_no_curve.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_no_curve.json
@@ -1,0 +1,21 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_no_signature_type.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_no_signature_type.json
@@ -1,0 +1,21 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_no_type.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_no_type.json
@@ -1,0 +1,21 @@
+{
+  "keyTypes": [
+    {
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_unkown_curve.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_unkown_curve.json
@@ -1,0 +1,22 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "bonkers",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_unkown_signature_type.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_ECDSA_key_unkown_signature_type.json
@@ -1,0 +1,22 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-MD2"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_RSA_key_no_length.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_RSA_key_no_length.json
@@ -1,0 +1,21 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "rsaEncryption",
+      "SignatureType": "sha256WithRSAEncryption"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_RSA_key_no_signature_type.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_RSA_key_no_signature_type.json
@@ -1,0 +1,21 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "rsaEncryption",
+      "PublicKeyLength": 2048
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_RSA_key_no_type.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_RSA_key_no_type.json
@@ -1,0 +1,21 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyLength": 2048,
+      "SignatureType": "sha256WithRSAEncryption"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_RSA_key_too_short.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_RSA_key_too_short.json
@@ -1,0 +1,22 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "rsaEncryption",
+      "PublicKeyLength": 1024,
+      "SignatureType": "sha256WithRSAEncryption"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_RSA_key_unknown_signature_type.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_RSA_key_unknown_signature_type.json
@@ -1,0 +1,22 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "rsaEncryption",
+      "PublicKeyLength": 2048,
+      "SignatureType": "bonkers"
+    }
+  ],
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_SAN_empty_DNSname.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_SAN_empty_DNSname.json
@@ -1,0 +1,27 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {
+      "DNS": []
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth",
+      "clientAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_SAN_empty_email.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_SAN_empty_email.json
@@ -1,0 +1,27 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {
+      "email": []
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth",
+      "clientAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_SAN_empty_uri.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_SAN_empty_uri.json
@@ -1,0 +1,27 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {
+      "URI": []
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth",
+      "clientAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_empty_DN.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_empty_DN.json
@@ -1,0 +1,23 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {},
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_empty_SAN.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_empty_SAN.json
@@ -1,0 +1,25 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {},
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth",
+      "clientAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_extensions_empty_extkeyusage.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_extensions_empty_extkeyusage.json
@@ -1,0 +1,29 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ],
+      "URI": [
+        "sip:voice.ndc.ido.example"
+      ],
+      "Email": [
+        "admin@ndc.ido.example"
+      ]
+    },
+    "extendedKeyUsage": []
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_extensions_empty_keyusage.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_extensions_empty_keyusage.json
@@ -1,0 +1,32 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ],
+      "URI": [
+        "sip:voice.ndc.ido.example"
+      ],
+      "Email": [
+        "admin@ndc.ido.example"
+      ]
+    },
+    "keyUsage": [],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_extensions_unknown_extkeyusage.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_extensions_unknown_extkeyusage.json
@@ -1,0 +1,31 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ],
+      "URI": [
+        "sip:voice.ndc.ido.example"
+      ],
+      "Email": [
+        "admin@ndc.ido.example"
+      ]
+    },
+    "extendedKeyUsage": [
+      "bonkers"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_extensions_unknown_keyusage.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_extensions_unknown_keyusage.json
@@ -1,0 +1,34 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ],
+      "URI": [
+        "sip:voice.ndc.ido.example"
+      ],
+      "Email": [
+        "admin@ndc.ido.example"
+      ]
+    },
+    "keyUsage": [
+      "bonkers"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_no_SAN.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_no_SAN.json
@@ -1,0 +1,24 @@
+{
+  "keyTypes": [
+    {
+      "PublicKeyType": "id-ecPublicKey",
+      "namedCurve": "secp521r1",
+      "SignatureType": "ecdsa-with-SHA512"
+    }
+  ],
+  "subject": {
+    "country": "CA",
+    "stateOrProvince": "**",
+    "locality": "**",
+    "commonName": "**"
+  },
+  "extensions": {
+    "keyUsage": [
+      "digitalSignature"
+    ],
+    "extendedKeyUsage": [
+      "serverAuth",
+      "clientAuth"
+    ]
+  }
+}

--- a/STAR-Delegation/CSR-template/test/FAIL_no_keyTypes.json
+++ b/STAR-Delegation/CSR-template/test/FAIL_no_keyTypes.json
@@ -1,0 +1,9 @@
+{
+  "extensions": {
+    "subjectAltName": {
+      "DNS": [
+        "cache.ndc.ido.example"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add a bunch of unit tests and fix the schemas accordingly.

Note that all tests currently defined pass under JSON-schema, while the
following tests:
* FAIL_empty_DN.json
* FAIL_empty_SAN.json
do not pass under CDDL.  I looks like a fundamental limitation of CDDL
to express co-constraints. These will need to be made explicit in prose.