### PR TITLE
allow-certificate-get clarifications

### DIFF
--- a/STAR-Delegation/draft-ietf-acme-star-delegation.md
+++ b/STAR-Delegation/draft-ietf-acme-star-delegation.md
@@ -641,8 +641,9 @@ following attribute in the `meta` field:
   the profile specified in this memo.  An ACME server that supports this
   delegation profile MUST include this key, and MUST set it to true.
 
-The `delegation-enabled` flag may be specified regardless of the existence or
-setting of the `auto-renewal` flag.
+The IdO MUST declare its support for delegation using `delegation-enabled`
+regardless of whether it supports delegation of STAR certificates, non-STAR
+certificates or both.
 
 In order to help a client to discover support for certificate fetching using
 unauthenticated HTTP GET, the directory object of an ACME server (typically,

--- a/STAR-Delegation/draft-ietf-acme-star-delegation.md
+++ b/STAR-Delegation/draft-ietf-acme-star-delegation.md
@@ -673,7 +673,7 @@ If the server accepts the request, it MUST reflect the attribute setting in the
 resulting order object.
 
 Note that even when the use of unauthenticated GET has been agreed upon, the
-server MUST also allow POST-as-GET requests to the star-certificate resource.
+server MUST also allow POST-as-GET requests to the certificate resource.
 
 ### Terminating the Delegation
 

--- a/STAR-Delegation/draft-ietf-acme-star-delegation.md
+++ b/STAR-Delegation/draft-ietf-acme-star-delegation.md
@@ -480,17 +480,21 @@ certificate has been issued by the CA, the IdO:
 ~~~
 {: #fig-star-ido-order-resource-updated title="STAR Order Resource Updated on IdO"}
 
-Before forwarding the Order request to the CA, the IdO SHOULD ensure that the
-selected CA supports "unauthenticated GET" by inspecting the relevant settings
-in the CA's `directory` object, as per Section 3.4 of {{!RFC8739}}.  If the CA
-does not support "unauthenticated GET" of STAR certificates, the IdO MUST NOT
-forward the Order request.  Instead, it MUST move the Order status to `invalid`
-and set the `allow-certificate-get` in the `auto-renewal` object to `false`.
-The same occurs in case the Order request is forwarded and the CA does not
-reflect the `allow-certificate-get` setting in its Order resource.  The
-combination of `invalid` status and denied `allow-certificate-get` in the Order
-resource at the IdO provides an unambiguous (asynchronous) signal to the NDC
-about the failure reason.
+This delegation protocol is predicated on the NDC being able to fetch
+certificates periodically using an unauthenticated HTTP GET, since in general
+the NDC does not possess an account on the CA and therefore cannot issue the
+standard POST-as-GET ACME request. Therefore, before forwarding the Order
+request to the CA, the IdO SHOULD ensure that the selected CA supports
+"unauthenticated GET" by inspecting the relevant settings in the CA's
+`directory` object, as per Section 3.4 of {{!RFC8739}}.  If the CA does not
+support "unauthenticated GET" of STAR certificates, the IdO MUST NOT forward
+the Order request.  Instead, it MUST move the Order status to `invalid` and set
+the `allow-certificate-get` in the `auto-renewal` object to `false`.  The same
+occurs in case the Order request is forwarded and the CA does not reflect the
+`allow-certificate-get` setting in its Order resource.  The combination of
+`invalid` status and denied `allow-certificate-get` in the Order resource at
+the IdO provides an unambiguous (asynchronous) signal to the NDC about the
+failure reason.
 
 #### CNAME Installation
 {: #sec-cname-installation}

--- a/STAR-Delegation/draft-ietf-acme-star-delegation.md
+++ b/STAR-Delegation/draft-ietf-acme-star-delegation.md
@@ -658,9 +658,17 @@ defines a mechanism that allows a server to advertise support for accessing
 certificate resources via unauthenticated GET (in addition to
 POST-as-GET), and a client to enable this service with per-Order granularity.
 
-Specifically, a server states its availability to grant unauthenticated access
-to a client's Order certificate by setting the `allow-certificate-get`
-attribute to `true` in the `meta` field inside the directory object:
+It is worth pointing out that the protocol elements described in this section
+have the same names and semantics as those introduced in Section 3.4 of
+{{!RFC8739}} for the STAR use case (except, of course, they apply to the
+certificate resource rather than the star-certificate resource).  However, they
+differ in terms of their position in the directory meta and order objects:
+rather than being wrapped in an auto-renewal sub-object they are located at the
+top-level.
+
+A server states its availability to grant unauthenticated access to a client's
+Order certificate by setting the `allow-certificate-get` attribute to `true` in
+the `meta` field inside the directory object:
 
 - allow-certificate-get (optional, boolean): If this field is present and set
   to `true`, the server allows GET (and HEAD) requests to certificate URLs.


### PR DESCRIPTION
* explain how `allow-certificate-get` is negotiated
* explain how `allow-certificate-get` is discovered

Fixes #172