### PR TITLE
avoid making it sound like a requirement

### DIFF
--- a/STAR-Delegation/draft-ietf-acme-star-delegation.md
+++ b/STAR-Delegation/draft-ietf-acme-star-delegation.md
@@ -185,7 +185,7 @@ The protocol assumes the following preconditions are met:
 - The NDC has registered an ACME account with the IdO;
 - NDC and IdO have agreed on a "CSR template" to use, including at a minimum:
   subject name (e.g., `abc.ido.example`), requested algorithms and key
-  length, key usage, extensions.  The NDC is required to use
+  length, key usage, extensions.  The NDC will use
   this template for every CSR created under the same delegation;
 - IdO has registered an ACME account with the Certification Authority (CA)
 


### PR DESCRIPTION
Do not say "NDC is required" because it gives out the wrong impression.
Replace the sentence with a purely informative "The NDC will use this
template for every CSR created under the same delegation" that doesn't
look like a requirement.

Fixes #174